### PR TITLE
MCMC Repeats

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,10 @@
 2017-08-08  Leah South  <leah.south@hdr.qut.edu.au>
 
-	* src/staticModelAdapt.cpp: Adding missing absolute value
-	to calculations of MCMC repeats.
+	* src/staticModelAdapt.cpp: Adding missing absolute value 
+	to calculations of MCMC repeats. 
+
+	* inst/include/history.h: Adding MCMC repeats to history.
+	* inst/include/sampler.h: Idem.
 
 2017-08-07  Leah South  <leah.south@hdr.qut.edu.au>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-08-08  Leah South  <leah.south@hdr.qut.edu.au>
+
+	* src/staticModelAdapt.cpp: Adding missing absolute value
+	to calculations of MCMC repeats.
+
 2017-08-07  Leah South  <leah.south@hdr.qut.edu.au>
 
 	* inst/include/staticModelAdapt.h: A class for commonly used

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@
 	* inst/include/history.h: Adding MCMC repeats to history.
 	* inst/include/sampler.h: Idem.
 
+	* inst/NEWS: Updating with recent issue tickets and pull requests.
+
 2017-08-07  Leah South  <leah.south@hdr.qut.edu.au>
 
 	* inst/include/staticModelAdapt.h: A class for commonly used

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,26 +5,15 @@
 
 \section{Changes in RcppSMC version 0.1.6 [unreleased] (2017-xx-yy)}{
   \itemize{
-    \item Also use \code{.registration=TRUE} in \code{useDynLib} in
-    \code{NAMESPACE}
-    \item The particles are now represented internally as a population 
-    level object rather than particle level objects. As a result, 
-    the user defined initialisation, move and MCMC functions 
-    take a different format (Leah South in \ghpr{2} and \ghpr{3}). 
-    \item Rcpp attributes are now used (Leah South in \ghpr{2}). 
-    \item The automatic RNGscope from Rcpp attributes is used 
-    (Leah South in \ghpr{4} and \ghpr{5}). 
-    \item Estimation of the log ratio of normalising constants 
-    can now be performed via the standard SMC estimator and 
-    multiple path sampling methods (Leah South in \ghpr{7}) 
-    \item A linear regression example has been added to  
-    demonstrate how the package can be used to perform  
-    inference for static Bayesian models and 
-    Bayesian model choice (Leah South in \ghit{9} 
-    and \ghpr{10}). 
-    \item An example of particle marginal Metropolis
-    Hastings has been added (Leah South in \ghit{11} 
-    and \ghpr{13}). 
+    \item Also use \code{.registration=TRUE} in \code{useDynLib} in \code{NAMESPACE}
+    \item Switching to population level objects (Leah South in \ghpr{2} and \ghpr{3}). 
+    \item Using Rcpp attributes (Leah South in \ghpr{2}). 
+    \item Using automatic RNGscope (Leah South in \ghpr{4} and \ghpr{5}). 
+    \item Adding multiple normalising constant estimators (Leah South in \ghpr{7}) 
+    \item Static Bayesian model example: linear regression  (Leah South in \ghit{9} and \ghpr{10}). 
+    \item Adding a PMMH example (Leah South in \ghit{11} and \ghpr{13}).
+    \item Framework for additional algorithm parameters and adaptation (Leah South in \ghit{16} and \ghpr{19}).
+    \item Common adaptation methods for static Bayesian models (Leah South in \ghit{17} and \ghpr{20}).
   }
 }
   

--- a/inst/include/history.h
+++ b/inst/include/history.h
@@ -1,6 +1,6 @@
 // -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
-// history.h: Rcpp integration of SMC library -- sampler history 
+// history.h: Rcpp integration of SMC library -- sampler history
 //
 // Copyright (C) 2008 - 2009  Adam Johansen
 // Copyright (C) 2017         Adam Johansen, Dirk Eddelbuettel and Leah South
@@ -53,6 +53,7 @@ namespace smc {
     private:
         long number; //!< The number of particles (presently redundant as this is not a function of iteration)
         int nAccepted; //!< Number of MCMC moves accepted during this iteration.
+        int nRepeat; //!< Number of MCMC iterations performed at this iteration (per particle)
         population<Space> pop; //!< The particles themselves (values and weights)
         historyflags flags; //!< Flags associated with this iteration.
         
@@ -60,7 +61,7 @@ namespace smc {
         /// The null constructor creates an empty history element.
         historyelement();
         /// A constructor with four arguments initialises the particle set.
-        historyelement(long lNumber, population<Space> pNew, int nAccepts, historyflags hf);
+        historyelement(long lNumber, population<Space> pNew, int nAccepts, int nRepeats, historyflags hf);
 
         /// The destructor tidies up.
         ~historyelement();
@@ -80,10 +81,12 @@ namespace smc {
         /// Monte Carlo estimate of the variance of the supplied function with respect to the empirical measure of the particle ensemble (to be used in second order trapezoidal correction).
         long double Integrate_Var(long lTime, double (*pIntegrand)(long,const Space&,void*), double Expectation, void* pAuxiliary) const;
         /// Sets the particle set to the specified values.
-        void Set(long lNumber, const population<Space> &New, int inAccepted, const historyflags &histflags){number = lNumber; pop = New; nAccepted = inAccepted; flags = histflags;};
+        void Set(long lNumber, const population<Space> &New, int inAccepted, int nRepeats, const historyflags &histflags){number = lNumber; pop = New; nAccepted = inAccepted; nRepeat = nRepeats; flags = histflags;};
 
         /// Returns the number of MCMC moves accepted during this iteration.
         int AcceptCount(void) {return nAccepted; }
+        /// Returns the number of MCMC iterations performed during this iteration.
+        int mcmcRepeats(void) {return nRepeat; }
         /// Returns true if the particle set 
         int WasResampled(void) {return flags.WasResampled(); }
 
@@ -97,17 +100,19 @@ namespace smc {
     {
         number = 0;
         nAccepted = 0;
+        nRepeat = 0;
     }
 
 
     /// \param lNumber The number of particles present in the particle generation
     /// \param New    The array of particles which are present in the particle generation
     /// \param nAccepts The number of MCMC moves that were accepted during this particle generation
+    /// \param nRepeats The number of MCMC iterations that were performed during this particle generation
     /// \param hf      The historyflags associated with the particle generation
 
     template <class Space>
-    historyelement<Space>::historyelement(long lNumber, population<Space> New, int nAccepts, historyflags hf) :
-    number(lNumber), nAccepted(nAccepts), pop(New), flags(hf)
+    historyelement<Space>::historyelement(long lNumber, population<Space> New, int nAccepts, int nRepeats, historyflags hf) :
+    number(lNumber), nAccepted(nAccepts), nRepeat(nRepeats), pop(New), flags(hf)
     {
     }
 

--- a/inst/include/sampler.h
+++ b/inst/include/sampler.h
@@ -339,7 +339,7 @@ namespace smc {
         if(htHistoryMode != HistoryType::NONE) {
             History.clear();
             historyelement<Space> histel;
-            histel.Set(N, pPopulation, nAccepted, historyflags(nResampled));
+            histel.Set(N, pPopulation, nAccepted, nRepeats, historyflags(nResampled));
             History.push_back(histel);          
         }  
 
@@ -403,7 +403,7 @@ namespace smc {
         throw SMC_EXCEPTION(SMCX_MISSING_HISTORY, "The path sampling integral cannot be computed as the history of the system was not stored.");
 
         // historyelement<Space> histel;
-        // histel.Set(N, pPopulation, nAccepted, historyflags(nResampled));
+        // histel.Set(N, pPopulation, nAccepted, nRepeats, historyflags(nResampled));
         // History.push_back(histel);
         
         
@@ -490,6 +490,7 @@ namespace smc {
         N =recent.GetNumber();
         nAccepted = recent.AcceptCount();
         nResampled = recent.WasResampled();
+        nRepeats = recent.mcmcRepeats();
         T--;
         return;
     }
@@ -537,7 +538,7 @@ namespace smc {
         //Finally, the current particle set should be appended to the historical process.
         if(htHistoryMode != HistoryType::NONE){
             historyelement<Space> histel;
-            histel.Set(N, pPopulation, nAccepted, historyflags(nResampled));
+            histel.Set(N, pPopulation, nAccepted, nRepeats, historyflags(nResampled));
             History.push_back(histel);
         }
         

--- a/src/staticModelAdapt.cpp
+++ b/src/staticModelAdapt.cpp
@@ -118,7 +118,7 @@ namespace smc {
     int staticModelAdapt::calcMcmcRepeats(double acceptProb, double desiredAcceptProb, int initialN, int maxReps){
         if (acceptProb + 1.0 <= 1e-9){
             return initialN;
-        } else if (acceptProb - 1.0 <= 1e-9){
+        } else if (fabs(acceptProb - 1.0) <= 1e-9){
             return 1;
         } else if (acceptProb <= 1e-9){
             return maxReps;


### PR DESCRIPTION
I accidentally left off an absolute value in one of the calculations for the MCMC repeats. This pull request is focused on
- fixing that issue
- storing the MCMC repeats in the history
- Adding a couple of items to NEWS (about the pull requests so far for adaptation)

Sorry this is a bit of a step backwards in terms of useful pull requests, but I figured it was preferable to do this separately to the next pull request which contains the examples. I have the code for that available [here](https://github.com/LeahPrice/rcppsmc/commit/2013e83e05f8da464146e1dbc4a0817d7ce69b5e) so I will create a pull request for it after this one is sorted.

I had issues with Gitkraken today and ended up having to set up the clone on my desktop again. I don't _think_ that caused any problems.

Can I please get your opinion on the Travis CI note below?

>   installed size is  6.8Mb
>   sub-directories of 1Mb or more:
>     libs   6.5Mb