### PR TITLE
Better handling of adaptation and algorithm parameters

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,15 +1,37 @@
 2017-08-11  Leah South  <leah.south@hdr.qut.edu.au>
 
-	* inst/include/adaptMethods.h: Changing the name (from algParams.h) and
-	removing the parameter object so it is not a member of the class.
+	* inst/include/adaptMethods.h: Changing the name (from algParams.h) and 
+	removing the parameter object so it is not a member of the class. 
 	Instead, it is passed by reference to the adaptation functions.
-	* inst/include/sampler.h: Adding the parameter object as a member of
-	this class and updating accordingly.
+	* inst/include/moveset.h: Passing a reference to the algorithm  
+	parameters to all functions. 
+	* inst/include/sampler.h: Adding the parameter object as a member of 
+	this class and updating accordingly. Passing the algorithm parameters
+	by reference to the adaptation and initialisation/move/MCMC functions.
+	parameters to all functions.
 
-	* inst/include/LinReg_LA_adapt.h: Switching to a pointer for the
-	sampler object and passing the parameter objects by reference to
-	the adaptation functions.
-	* src/LinReg_LA_adapt.cpp: Idem.
+	* inst/include/LinReg_LA_adapt.h: Switching to a pointer for the 
+	sampler object and passing the parameter objects by reference to 
+	the adaptation and move functions.
+	* src/LinReg_LA_adapt.cpp:  Idem. Also adding the adaptation object
+	type to the template arguments for moveset.
+
+	* inst/include/blockpfgaussianopt.h: Adding params to the moveset
+	function arguments with an empty class as the type.
+	* inst/include/LinReg.h: Idem.
+	* inst/include/LinReg_LA.h: Idem.
+	* inst/include/nonLinPMMH.h: Idem.
+	* inst/include/pflineart.h: Idem.
+	* inst/include/pfnonlinbs.h: Idem.
+
+	* src/blockpfgaussianopt.cpp: Adding params to the moveset
+	function arguments and template arguments for sampler and moveset.
+	Using an empty class as the type.
+	* src/LinReg.cpp: Idem.
+	* src/LinReg_LA.cpp: Idem.
+	* src/nonLinPMMH.cpp: Idem.
+	* src/pflineart.cpp: Idem.
+	* src/pfnonlinbs.cpp: Idem.
 
 2017-08-09  Leah South  <leah.south@hdr.qut.edu.au>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2017-08-11  Leah South  <leah.south@hdr.qut.edu.au>
+
+	* inst/include/adaptMethods.h: Changing the name (from algParams.h) and
+	removing the parameter object so it is not a member of the class.
+	Instead, it is passed by reference to the adaptation functions.
+	* inst/include/sampler.h: Adding the parameter object as a member of
+	this class and updating accordingly.
+
+	* inst/include/LinReg_LA_adapt.h: Switching to a pointer for the
+	sampler object and passing the parameter objects by reference to
+	the adaptation functions.
+	* src/LinReg_LA_adapt.cpp: Idem.
+
 2017-08-09  Leah South  <leah.south@hdr.qut.edu.au>
 
 	* R/LinReg.R: Accessing radiata data through RcppSMC:: namespace rather
@@ -62,7 +75,7 @@
 2017-08-04  Leah South  <leah.south@hdr.qut.edu.au>
 
 	* R/LinReg.R: Silencing R CMD check --as-cran by not loading
-    data(radiata) into the global workspace.
+	data(radiata) into the global workspace.
 	* R/LinRegLA.R: Idem.
 	* inst/NEWS: Adding a line for each of the recent major changes.
 

--- a/inst/include/LinReg.h
+++ b/inst/include/LinReg.h
@@ -41,7 +41,7 @@ namespace LinReg {
     
     double logWeight(long lTime, const rad_state & value);
     double logPosterior(long lTime, const rad_state & value);
-    void fInitialise(rad_state & value, double & logweight);
-    void fMove(long lTime, rad_state & value, double & logweight);
-    bool fMCMC(long lTime, rad_state & value, double & logweight);
+    void fInitialise(rad_state & value, double & logweight, smc::nullParams & param);
+    void fMove(long lTime, rad_state & value, double & logweight, smc::nullParams & param);
+    bool fMCMC(long lTime, rad_state & value, double & logweight, smc::nullParams & param);
 }

--- a/inst/include/LinReg_LA.h
+++ b/inst/include/LinReg_LA.h
@@ -46,9 +46,9 @@ namespace LinReg_LA {
     double logLikelihood(const rad_state & value);
     double logPrior(const rad_state & value);
     
-    void fInitialise(rad_state & value, double & logweight);
-    void fMove(long lTime, rad_state & value, double & logweight);
-    bool fMCMC(long lTime, rad_state & value, double & logweight);
+    void fInitialise(rad_state & value, double & logweight, smc::nullParams & param);
+    void fMove(long lTime, rad_state & value, double & logweight, smc::nullParams & param);
+    bool fMCMC(long lTime, rad_state & value, double & logweight, smc::nullParams & param);
     
     double integrand_ps(long,const rad_state &, void *);
     double width_ps(long, void *);

--- a/inst/include/LinReg_LA_adapt.h
+++ b/inst/include/LinReg_LA_adapt.h
@@ -48,9 +48,9 @@ namespace LinReg_LA_adapt {
     double logLikelihood(const rad_state & value);
     double logPrior(const rad_state & value);
     
-    void fInitialise(rad_state & value, double & logweight);
-    void fMove(long lTime, rad_state & value, double & logweight);
-    bool fMCMC(long lTime, rad_state & value, double & logweight);
+    void fInitialise(rad_state & value, double & logweight, smc::staticModelAdapt & param);
+    void fMove(long lTime, rad_state & value, double & logweight, smc::staticModelAdapt & param);
+    bool fMCMC(long lTime, rad_state & value, double & logweight, smc::staticModelAdapt & param);
     
     double integrand_ps(long,const rad_state &, void *);
     double width_ps(long, void *);

--- a/inst/include/LinReg_LA_adapt.h
+++ b/inst/include/LinReg_LA_adapt.h
@@ -55,12 +55,13 @@ namespace LinReg_LA_adapt {
     double integrand_ps(long,const rad_state &, void *);
     double width_ps(long, void *);
     
+    //A derived class for adaptation which adapts parameters of type smc::staticModelAdapt
     class rad_adapt:
-    public smc::algParam<rad_state,smc::staticModelAdapt>
+    public smc::adaptMethods<rad_state,smc::staticModelAdapt>
     {
     public:
 
-        void updateForMove(const smc::population<rad_state> & pop) {
+        void updateForMove(smc::staticModelAdapt & param, const smc::population<rad_state> & pop) {
             unsigned long N = pop.GetNumber();
             arma::vec loglike(N);
             for (unsigned int i=0; i<N; i++){
@@ -69,7 +70,7 @@ namespace LinReg_LA_adapt {
             param.ChooseTemp(pop.GetLogWeight(),loglike,rho*N);
         }
 
-        void updateForMCMC(const smc::population<rad_state> & pop, double acceptProb, int nResampled, int & nRepeats) {
+        void updateForMCMC(smc::staticModelAdapt & param, const smc::population<rad_state> & pop, double acceptProb, int nResampled, int & nRepeats) {
             if (nResampled == 0) {
                 nRepeats = 0;
             } else {
@@ -87,6 +88,6 @@ namespace LinReg_LA_adapt {
 
     };
 
-    smc::algParam<rad_state,smc::staticModelAdapt> * myParams;
-    
+    smc::sampler<rad_state,smc::staticModelAdapt> * Sampler;
+    smc::adaptMethods<rad_state,smc::staticModelAdapt> * myAdapt;
 }

--- a/inst/include/adaptMethods.h
+++ b/inst/include/adaptMethods.h
@@ -1,6 +1,6 @@
 // -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
-// algParam: A class that holds all of the algorithm parameters that can be adapted
+// adaptMethods: A class that adapts the algorithm parameters
 //
 // Copyright (C) 2017         Dirk Eddelbuettel, Adam Johansen and Leah South
 //
@@ -21,12 +21,11 @@
 
 
 //! \file
-//! \brief A base class containing algorithm parameters and virtual
-//! functions to adapt them.
+//! \brief A base class with virtual functions to adapt parameters
 //!
 
-#ifndef __SMC_ALGPARAM_H
-#define __SMC_ALGPARAM_H 1.0
+#ifndef __SMC_ADAPTMETHODS_H
+#define __SMC_ADAPTMETHODS_H 1.0
 
 #include <population.h>
 
@@ -34,28 +33,22 @@
 namespace smc {
 
     /// A base class which contains the algorithm parameters and virtual functions to adapt them.
-    template <class Space, class Params> class algParam {
-
-    protected:
-        Params param;
-
+    template <class Space, class Params> class adaptMethods {
+ 
     public:
 
         /// Free the workspace allocated for the algorithm parameters.
-        virtual ~algParam() {
+        virtual ~adaptMethods() {
         }
 
         /// Holder function for updates to be done before the move step.
-        virtual void updateForMove(const population<Space> & pop) {}
+        virtual void updateForMove(Params &, const population<Space> & pop) {}
 
         /// Holder function for updates to be done before the MCMC step.
-        virtual void updateForMCMC(const population<Space> & pop, double acceptProb, int nResampled, int & nRepeats) {}
+        virtual void updateForMCMC(Params &, const population<Space> & pop, double acceptProb, int nResampled, int & nRepeats) {}
 
         /// Holder function for updates to be done at the end of each iteration.
-        virtual void updateEnd(const population<Space> & pop) {}
-
-        /// Returns the parameters.
-        const Params & GetParams(void) const {return param;}
+        virtual void updateEnd(Params &, const population<Space> & pop) {}
     };
 }
 

--- a/inst/include/blockpfgaussianopt.h
+++ b/inst/include/blockpfgaussianopt.h
@@ -22,7 +22,7 @@
 
 #include "smctc.h"
 
-namespace BSPFG {
-    void fInitialise(arma::vec & value, double & logweight);
-    void fMove(long lTime, arma::vec & value, double & logweight);
+namespace BSPFG {    
+    void fInitialise(arma::vec & value, double & logweight, smc::nullParams & param);
+    void fMove(long lTime, arma::vec & value, double & logweight, smc::nullParams & param);
 }

--- a/inst/include/nonLinPMMH.h
+++ b/inst/include/nonLinPMMH.h
@@ -33,8 +33,8 @@ namespace nonLinPMMH {
     arma::vec y; //data
     
     double logPrior(const parameters & proposal);
-    void fInitialise(double & value, double & logweight);
-    void fMove(long lTime, double & value, double & logweight);
+    void fInitialise(double & value, double & logweight, smc::nullParams & param);
+    void fMove(long lTime, double & value, double & logweight, smc::nullParams & param);
     
     parameters theta_prop;
 }

--- a/inst/include/pflineart.h
+++ b/inst/include/pflineart.h
@@ -39,8 +39,8 @@ namespace pflineart {
 
     double logLikelihood(long lTime, const cv_state & X);
 
-    void fInitialise(cv_state & value, double & logweight);
-    void fMove(long lTime, cv_state & value, double & logweight);
+    void fInitialise(cv_state & value, double & logweight, smc::nullParams & param);
+    void fMove(long lTime, cv_state & value, double & logweight, smc::nullParams & param);
 
     double integrand_mean_x(const cv_state&, void*);
     double integrand_mean_y(const cv_state&, void*);

--- a/inst/include/pfnonlinbs.h
+++ b/inst/include/pfnonlinbs.h
@@ -29,9 +29,9 @@
 
 namespace nonlinbs {
     double logLikelihood(long lTime, const double & X);
-
-    void fInitialise(double & value, double & logweight);
-    void fMove(long lTime, double & value, double & logweight);
+    
+    void fInitialise(double & value, double & logweight, smc::nullParams & param);
+    void fMove(long lTime, double & value, double & logweight, smc::nullParams & param);
 
     double integrand_mean_x(const double&, void*);
     double integrand_var_x(const double&, void*);

--- a/src/LinReg.cpp
+++ b/src/LinReg.cpp
@@ -56,8 +56,8 @@ Rcpp::List LinReg_impl(arma::mat Data, unsigned long lNumber) {
         mean_x = arma::sum(data.x)/lIterates;
         
         //Initialise and run the sampler
-        smc::sampler<rad_state> Sampler(lNumber, HistoryType::RAM);  
-        smc::moveset<rad_state> Moveset(fInitialise, fMove, fMCMC);
+        smc::sampler<rad_state,smc::nullParams> Sampler(lNumber, HistoryType::RAM);  
+        smc::moveset<rad_state,smc::nullParams> Moveset(fInitialise, fMove, fMCMC);
         
         Sampler.SetResampleParams(ResampleType::MULTINOMIAL, 0.5);
         Sampler.SetMoveSet(Moveset);
@@ -124,7 +124,8 @@ namespace LinReg {
 
     /// \param value        Reference to the empty particle value
     /// \param logweight    Refernce to the empty particle log weight
-    void fInitialise(rad_state & value, double & logweight)
+    /// \param param        Additional algorithm parameters
+    void fInitialise(rad_state & value, double & logweight, smc::nullParams & param)
     {
         value.theta = arma::zeros(3);
         // drawing from the prior
@@ -140,7 +141,8 @@ namespace LinReg {
     /// \param lTime        The sampler iteration.
     /// \param value        Reference to the current particle value
     /// \param logweight    Refernce to the current particle log weight
-    void fMove(long lTime, rad_state & value, double & logweight)
+    /// \param param        Additional algorithm parameters
+    void fMove(long lTime, rad_state & value, double & logweight, smc::nullParams & param)
     {
         logweight += logWeight(lTime, value);
     }
@@ -150,7 +152,8 @@ namespace LinReg {
     /// \param lTime        The sampler iteration.
     /// \param value        Reference to the current particle value
     /// \param logweight    Reference to the log weight of the particle being moved
-    bool fMCMC(long lTime, rad_state & value, double & logweight)
+    /// \param param        Additional algorithm parameters
+    bool fMCMC(long lTime, rad_state & value, double & logweight, smc::nullParams & param)
     {
         double logposterior_curr = logPosterior(lTime, value);
         

--- a/src/LinReg_LA.cpp
+++ b/src/LinReg_LA.cpp
@@ -57,8 +57,8 @@ Rcpp::List LinRegLA_impl(arma::mat Data, arma::vec intemps, unsigned long lNumbe
         long lTemps = temps.n_rows;
         
         //Initialise and run the sampler
-        smc::sampler<rad_state> Sampler(lNumber, HistoryType::RAM);
-        smc::moveset<rad_state> Moveset(fInitialise, fMove, fMCMC);
+        smc::sampler<rad_state,smc::nullParams> Sampler(lNumber, HistoryType::RAM);
+        smc::moveset<rad_state,smc::nullParams> Moveset(fInitialise, fMove, fMCMC);
         
         Sampler.SetResampleParams(ResampleType::SYSTEMATIC, 0.5);
         Sampler.SetMoveSet(Moveset);
@@ -140,7 +140,8 @@ namespace LinReg_LA {
 
     /// \param value        Reference to the empty particle value
     /// \param logweight    Refernce to the empty particle log weight
-    void fInitialise(rad_state & value, double & logweight)
+    /// \param param        Additional algorithm parameters
+    void fInitialise(rad_state & value, double & logweight, smc::nullParams & param)
     {
         // drawing from the prior
         value.theta = arma::zeros(3);
@@ -157,17 +158,19 @@ namespace LinReg_LA {
     ///\param lTime         The sampler iteration.
     /// \param value        Reference to the current particle value
     /// \param logweight    Refernce to the current particle log weight
-    void fMove(long lTime, rad_state & value, double & logweight)
+    /// \param param        Additional algorithm parameters
+    void fMove(long lTime, rad_state & value, double & logweight, smc::nullParams & param)
     {
         logweight += (temps(lTime) - temps(lTime-1))*logLikelihood(value);
     }
 
-    ///The proposal function.
+    ///The MCMC function.
 
     ///\param lTime         The sampler iteration.
     ///\param value         Reference to the value of the particle being moved
     ///\param logweight     Reference to the log weight of the particle being moved
-    bool fMCMC(long lTime, rad_state & value, double & logweight)
+    ///\param param         Additional algorithm parameters
+    bool fMCMC(long lTime, rad_state & value, double & logweight, smc::nullParams & param)
     {
         rad_state value_prop;
         value_prop.theta = value.theta + cholCovRW*Rcpp::as<arma::vec>(Rcpp::rnorm(3));            

--- a/src/LinReg_LA_adapt.cpp
+++ b/src/LinReg_LA_adapt.cpp
@@ -46,24 +46,26 @@ Rcpp::List LinRegLA_adapt_impl(arma::mat Data, unsigned long lNumber, double res
         mean_x = arma::sum(data.x)/lIterates;
         
         // Initialise the sampler
-        myParams = new rad_adapt;
-        smc::sampler<rad_state,smc::staticModelAdapt> Sampler(lNumber, HistoryType::RAM, myParams);
+        myAdapt = new rad_adapt;
+        Sampler = new smc::sampler<rad_state,smc::staticModelAdapt>(lNumber, HistoryType::RAM);
         smc::moveset<rad_state> Moveset(fInitialise, fMove, fMCMC);
         
-        Sampler.SetResampleParams(ResampleType::SYSTEMATIC, resampTol);
-        Sampler.SetMoveSet(Moveset);
-        Sampler.Initialise();
+        Sampler->SetResampleParams(ResampleType::SYSTEMATIC, resampTol);
+        Sampler->SetMoveSet(Moveset);
+        Sampler->SetAlgParam(smc::staticModelAdapt());  
+        Sampler->SetAdaptMethods(myAdapt);
+        Sampler->Initialise();
         
         //Run the sampler
-        while (myParams->GetParams().GetTempCurr() != 1){
-            Sampler.Iterate();
-        }           
+        while (Sampler->GetAlgParams().GetTempCurr() != 1){
+            Sampler->Iterate();
+        }
         
         //Storing the results in a sensible format
-        std::vector<double> temps = myParams->GetParams().GetTemps();
+        std::vector<double> temps = Sampler->GetAlgParams().GetTemps();
         int lTemps = temps.size();
         
-        std::vector<smc::historyelement<rad_state> > Hist = Sampler.GetHistory();
+        std::vector<smc::historyelement<rad_state> > Hist = Sampler->GetHistory();
         
         arma::cube theta(lNumber,3,lTemps);
         arma::mat loglike(lNumber,lTemps), logprior(lNumber,lTemps), Weights(lNumber,lTemps);
@@ -80,12 +82,12 @@ Rcpp::List LinRegLA_adapt_impl(arma::mat Data, unsigned long lNumber, double res
             mcmcRepeats(n) = Hist[n].mcmcRepeats();
         }
         
-        double logNC_standard = Sampler.GetLogNCPath();
-        double logNC_ps_trap2 = Sampler.IntegratePathSampling(integrand_ps,width_ps, NULL);
-        double logNC_ps_rect = Sampler.IntegratePathSampling(PathSamplingType::RECTANGLE,integrand_ps,width_ps, NULL);
-        double logNC_ps_trap = Sampler.IntegratePathSampling(PathSamplingType::TRAPEZOID1,integrand_ps,width_ps, NULL);
+        double logNC_standard = Sampler->GetLogNCPath();
+        double logNC_ps_trap2 = Sampler->IntegratePathSampling(integrand_ps,width_ps, NULL);
+        double logNC_ps_rect = Sampler->IntegratePathSampling(PathSamplingType::RECTANGLE,integrand_ps,width_ps, NULL);
+        double logNC_ps_trap = Sampler->IntegratePathSampling(PathSamplingType::TRAPEZOID1,integrand_ps,width_ps, NULL);
         
-        delete myParams;
+        delete myAdapt;
 
         return Rcpp::List::create(
         Rcpp::Named("theta") = theta,
@@ -111,7 +113,7 @@ namespace LinReg_LA_adapt {
     double integrand_ps(long lTime,const rad_state & value,  void *) { return logLikelihood(value);}    
 
     double width_ps(long lTime, void *){
-        return (myParams->GetParams().GetTemp(lTime) - myParams->GetParams().GetTemp(lTime-1));
+        return (Sampler->GetAlgParams().GetTemp(lTime) - Sampler->GetAlgParams().GetTemp(lTime-1));
     }   
 
     ///The function corresponding to the log likelihood at specified position
@@ -142,7 +144,7 @@ namespace LinReg_LA_adapt {
         value.theta(2) = log(pow(R::rgamma(3,pow(2.0*300.0*300.0,-1.0)),-1.0));
         value.loglike = logLikelihood(value);
         value.logprior = logPrior(value);
-        logweight = myParams->GetParams().GetTemp(0)*value.loglike;
+        logweight = Sampler->GetAlgParams().GetTemp(0)*value.loglike;
     }
 
     ///The proposal function.
@@ -152,10 +154,10 @@ namespace LinReg_LA_adapt {
     /// \param logweight    Refernce to the current particle log weight
     void fMove(long lTime, rad_state & value, double & logweight)
     {
-        logweight += (myParams->GetParams().GetTemp(lTime) - myParams->GetParams().GetTemp(lTime-1))*logLikelihood(value);
+        logweight += (Sampler->GetAlgParams().GetTemp(lTime) - Sampler->GetAlgParams().GetTemp(lTime-1))*logLikelihood(value);
     }
 
-    ///The proposal function.
+    ///The MCMC function.
 
     ///\param lTime         The sampler iteration.
     ///\param value         Reference to the value of the particle being moved
@@ -163,11 +165,11 @@ namespace LinReg_LA_adapt {
     bool fMCMC(long lTime, rad_state & value, double & logweight)
     {
         rad_state value_prop;
-        value_prop.theta = value.theta + myParams->GetParams().GetCholCov()*Rcpp::as<arma::vec>(Rcpp::rnorm(3));            
+        value_prop.theta = value.theta + Sampler->GetAlgParams().GetCholCov()*Rcpp::as<arma::vec>(Rcpp::rnorm(3));            
         value_prop.loglike = logLikelihood(value_prop);
         value_prop.logprior = logPrior(value_prop);
         
-        double MH_ratio = exp(myParams->GetParams().GetTemp(lTime)*(value_prop.loglike - value.loglike) + value_prop.logprior - value.logprior);
+        double MH_ratio = exp(Sampler->GetAlgParams().GetTemp(lTime)*(value_prop.loglike - value.loglike) + value_prop.logprior - value.logprior);
         
         if (MH_ratio>R::runif(0,1)){
             value = value_prop;

--- a/src/blockpfgaussianopt.cpp
+++ b/src/blockpfgaussianopt.cpp
@@ -47,8 +47,8 @@ Rcpp::List blockpfGaussianOpt_impl(arma::vec data, long part, long lag)
     lIterates = y.size();
 
     //Initialise and run the sampler
-    smc::sampler<arma::vec> Sampler(lNumber, HistoryType::NONE);  
-    smc::moveset<arma::vec> Moveset(fInitialise, fMove, NULL);
+    smc::sampler<arma::vec,smc::nullParams> Sampler(lNumber, HistoryType::NONE);  
+    smc::moveset<arma::vec,smc::nullParams> Moveset(fInitialise, fMove, NULL);
 
     Sampler.SetResampleParams(ResampleType::SYSTEMATIC, 0.5);
     Sampler.SetMoveSet(Moveset);
@@ -76,7 +76,8 @@ namespace BSPFG {
     ///
     /// \param value The value of the particle being moved
     /// \param logweight The log weight of the particle being moved
-    void fInitialise(arma::vec & value, double & logweight)
+    /// \param param Additional algorithm parameters
+    void fInitialise(arma::vec & value, double & logweight, smc::nullParams & param)
     {
         value = arma::zeros<arma::vec>(lIterates);
         value(0) = R::rnorm(0.5 * y(0),1.0/sqrt(2.0));
@@ -88,7 +89,8 @@ namespace BSPFG {
     ///\param lTime The sampler iteration.
     ///\param value The value of the particle being moved
     ///\param logweight The log weight of the particle being moved
-    void fMove(long lTime, arma::vec & value, double & logweight)
+    ///\param param Additional algorithm parameters
+    void fMove(long lTime, arma::vec & value, double & logweight, smc::nullParams & param)
     {
         if(lTime == 1) {
             value(lTime) = (value(lTime-1) + y(lTime))/2.0 + R::rnorm(0.0,1.0/sqrt(2.0));

--- a/src/nonLinPMMH.cpp
+++ b/src/nonLinPMMH.cpp
@@ -48,7 +48,7 @@ Rcpp::DataFrame nonLinPMMH_impl(arma::vec data, unsigned long lNumber, unsigned 
         double logprior_prop;
 
         //Initialise and run the sampler
-        smc::sampler<double> Sampler(lNumber, HistoryType::NONE);
+        smc::sampler<double,smc::nullParams> Sampler(lNumber, HistoryType::NONE);
         theta_prop.sigv = 10.0;
         theta_prop.sigw = 10.0;
 
@@ -60,7 +60,7 @@ Rcpp::DataFrame nonLinPMMH_impl(arma::vec data, unsigned long lNumber, unsigned 
         Rcpp::NumericVector unifRands = Rcpp::runif(lMCMCits);
 
         // Getting a particle filtering estimate of the log likelihood.
-        smc::moveset<double> Moveset(fInitialise, fMove, NULL);
+        smc::moveset<double,smc::nullParams> Moveset(fInitialise, fMove, NULL);
         Sampler.SetResampleParams(ResampleType::MULTINOMIAL, 0.5);
         Sampler.SetMoveSet(Moveset);
         Sampler.Initialise();
@@ -125,7 +125,8 @@ namespace nonLinPMMH {
 
     /// \param X            A reference to the empty particle value
     /// \param logweight    A reference to the empty particle log weight
-    void fInitialise(double & X, double & logweight)
+    /// \param param        Additional algorithm parameters
+    void fInitialise(double & X, double & logweight, smc::nullParams & param)
     {
         X = R::rnorm(0.0,sqrt(5.0));
         double mean = pow(X,2)/20.0;
@@ -137,7 +138,8 @@ namespace nonLinPMMH {
     /// \param lTim     The sampler iteration.
     /// \param X            A reference to the current particle value
     /// \param logweight    A reference to the current particle log weight
-    void fMove(long lTime, double & X, double & logweight)
+    /// \param param        Additional algorithm parameters
+    void fMove(long lTime, double & X, double & logweight, smc::nullParams & param)
     {
         X = X/2.0 + 25.0*X/(1+pow(X,2)) + 8*cos(1.2*(lTime+1)) + R::rnorm(0.0,theta_prop.sigv);
         double mean = pow(X,2)/20.0;

--- a/src/pflineart.cpp
+++ b/src/pflineart.cpp
@@ -62,8 +62,8 @@ Rcpp::DataFrame pfLineartBS_impl(arma::mat data, unsigned long part, bool usef, 
         y.y_pos = data.col(1);
 
         //Initialise and run the sampler
-        smc::sampler<cv_state> Sampler(lNumber, HistoryType::NONE);  
-        smc::moveset<cv_state> Moveset(fInitialise, fMove, NULL);
+        smc::sampler<cv_state,smc::nullParams> Sampler(lNumber, HistoryType::NONE);  
+        smc::moveset<cv_state,smc::nullParams> Moveset(fInitialise, fMove, NULL);
 
         Sampler.SetResampleParams(ResampleType::RESIDUAL, 0.5);
         Sampler.SetMoveSet(Moveset);
@@ -141,7 +141,8 @@ namespace pflineart {
 
     /// \param value The value of the particle being moved
     /// \param logweight The log weight of the particle being moved
-    void fInitialise(cv_state & value, double & logweight)
+    /// \param param Additional algorithm parameters
+    void fInitialise(cv_state & value, double & logweight, smc::nullParams & param)
     {
         value.x_pos = R::rnorm(0.0,sqrt(var_s0));
         value.y_pos = R::rnorm(0.0,sqrt(var_s0));
@@ -156,7 +157,8 @@ namespace pflineart {
     ///\param lTime The sampler iteration.
     ///\param value The value of the particle being moved
     ///\param logweight The log weight of the particle being moved
-    void fMove(long lTime, cv_state & value, double & logweight)
+    /// \param param Additional algorithm parameters
+    void fMove(long lTime, cv_state & value, double & logweight, smc::nullParams & param)
     {
         value.x_pos += value.x_vel * Delta + R::rnorm(0.0,sqrt(var_s));
         value.x_vel += R::rnorm(0.0,sqrt(var_u));

--- a/src/pfnonlinbs.cpp
+++ b/src/pfnonlinbs.cpp
@@ -56,8 +56,8 @@ Rcpp::List pfNonlinBS_impl(arma::vec data, long part) {
     long lIterates = y.n_rows;
 
     //Initialise and run the sampler
-    smc::sampler<double> Sampler(lNumber, HistoryType::NONE);  
-    smc::moveset<double> Moveset(fInitialise, fMove, NULL);
+    smc::sampler<double,smc::nullParams> Sampler(lNumber, HistoryType::NONE);  
+    smc::moveset<double,smc::nullParams> Moveset(fInitialise, fMove, NULL);
 
     Sampler.SetResampleParams(ResampleType::MULTINOMIAL, 1.01 * lNumber);
     Sampler.SetMoveSet(Moveset);
@@ -90,7 +90,8 @@ namespace nonlinbs {
 
     /// \param value The value of the particle being moved
     /// \param logweight The log weight of the particle being moved
-    void fInitialise(double & value, double & logweight) {
+    /// \param param Additional algorithm parameters
+    void fInitialise(double & value, double & logweight, smc::nullParams & param) {
         value = R::rnorm(0.0,std_x0);
         logweight = logLikelihood(0,value);
     }
@@ -100,7 +101,8 @@ namespace nonlinbs {
     /// \param lTime The sampler iteration.
     /// \param value The value of the particle being moved
     /// \param logweight The log weight of the particle being moved
-    void fMove(long lTime, double & value, double & logweight) {
+    /// \param param Additional algorithm parameters
+    void fMove(long lTime, double & value, double & logweight, smc::nullParams & param) {
         value = 0.5 * value + 25.0*value / (1.0 + value * value) + 8.0 * cos(1.2  * ( lTime)) + R::rnorm(0.0,std_x);
         logweight += logLikelihood(lTime, value);
     }


### PR DESCRIPTION
Following on from our discussion in #23, I'm now passing the algorithm parameters to all of the necessary functions.

The first commit separates the algorithm parameters and adaptation object. The algorithm parameters are passed to the adaptation functions and accessed elsewhere through Sampler->GetAlgParams(). The second commit goes further to pass the algorithm parameters to the moveset functions as well.

Sorry about all of the white space changes hiking up the addition/deletion numbers. I'm not even sure how I would have gone about changing a whole section of indentation like that, but I had the ignore white space option in Gitkraken turned on so I didn't notice (I've turn it off now).